### PR TITLE
Pulse Ceph Perf Counters Collector Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+.idea
+tmp/
+*.tmp
+scratch/
+build/
+*.swp
+profile.cov
+gin-bin
+
+# we don't vendor godep _workspace
+**/Godeps/_workspace/**
+
+# OSX stuff
+.DS_Store

--- a/.netrc
+++ b/.netrc
@@ -1,0 +1,3 @@
+machine github.com
+  login intelsdibot
+  password 0f60cedb3c004ae0a79c24e6b30ce416ab4fcc49

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: false
+language: go
+go:
+- 1.4.2
+- 1.5
+before_install:
+- cp .netrc ~
+- chmod 600 .netrc
+- go get github.com/tools/godep
+- if [ ! -d $PULSE_PLUGIN_SOURCE ]; then mkdir -p $HOME/gopath/src/github.com/intelsdi-x; ln -s $TRAVIS_BUILD_DIR $PULSE_PLUGIN_SOURCE; fi # CI for forks not from intelsdi-x
+env:
+  global:
+    - PULSE_PLUGIN_SOURCE=/home/travis/gopath/src/github.com/intelsdi-x/pulse-plugin-collector-ceph
+  matrix:
+    - TEST=unit
+install:
+- export TMPDIR=$HOME/tmp
+- mkdir -p $TMPDIR
+- cd $PULSE_PLUGIN_SOURCE # change dir into source
+- make deps
+script:
+- make check TEST=$TEST 2>&1 # Run test suite
+notifications:
+  slack:
+    secure: VkbZLIc2RH8yf3PtIAxUNPdAu3rQQ7yQx0GcK124JhbEnZGaHyK615V0rbG7HcVmYKGPdB0cXqZiLBDKGqGKb2zR1NepOe1nF03jxGSpPq8jIFeEXSJGEYGL34ScDzZZGuG6qwbjFcXiW5lqn6t8igzp7v2+URYBaZo5ktCS2xY=

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,16 @@
+{
+	"ImportPath": "github.com/intelsdi-x/pulse-plugin-collector-ceph",
+	"GoVersion": "go1.4.2",
+	"Deps": [
+		{
+			"ImportPath": "github.com/intelsdi-x/pulse",
+			"Comment": "v0.8.0-beta",
+			"Rev": "de2881352745c206284b74f4ef1165ba4510971a"
+		},
+		{
+			"ImportPath": "github.com/smartystreets/goconvey/convey",
+			"Comment": "1.5.0-386-geb2e83c",
+			"Rev": "eb2e83c1df892d2c9ad5a3c85672da30be585dfd"
+		}
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/MDS_PERFCNT.md
+++ b/MDS_PERFCNT.md
@@ -1,0 +1,218 @@
+<!--
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+## Pulse Ceph Perf Counters Collector Plugin
+
+
+# Ceph MDS Perf Counters
+
+Prefix: /intel/storage/ceph/{mds_daemon_name}/
+
+Metrics | Description
+------------ | -------------
+mds/request | Requests
+mds/reply | Replies
+mds/reply_latency/avgcount | Reply latency
+mds/reply_latency/sum | Reply latency
+mds/forward | Forwarding request
+mds/dir_fetch | Directory fetch
+mds/dir_commit | Directory commit
+mds/dir_split | Directory split
+mds/inode_max | Max inodes cache size
+mds/inodes | Inodes
+mds/inodes_top | Inodes on top
+mds/inodes_bottom | Inodes on bottom
+mds/inodes_pin_tail | Inodes on pin tail
+mds/inodes_pinned | Inodes pinned
+mds/inodes_expired | Inodes expired
+mds/inodes_with_caps | Inodes with capabilities
+mds/caps | Capabilities
+mds/subtrees | Subtrees
+mds/traverse | Traverses
+mds/traverse_hit | Traverse hits
+mds/traverse_forward | Traverse forwards
+mds/traverse_discover | Traverse directory discovers
+mds/traverse_dir_fetch | Traverse incomplete directory content fetchings
+mds/traverse_remote_ino | Traverse remote dentries
+mds/traverse_lock | Traverse locks
+mds/load_cent | Load per cent
+mds/q | Dispatch queue length
+mds/exported | Exports
+mds/exported_inodes | Exported inodes
+mds/imported | Imports
+mds/imported_inodes | Imported inodes
+ | 
+mds_cache/num_strays | Stray dentries
+mds_cache/num_strays_purging | Stray dentries purging
+mds_cache/num_strays_delayed | Stray dentries delayed
+mds_cache/num_purge_ops | Purge operations
+mds_cache/strays_created | Stray dentries created
+mds_cache/strays_purged | Stray dentries purged
+mds_cache/strays_reintegrated | Stray dentries reintegrated
+mds_cache/strays_migrated | Stray dentries migrated
+mds_cache/num_recovering_processing | Files currently being recovered
+mds_cache/num_recovering_enqueued | Files waiting for recovery
+mds_cache/num_recovering_prioritized | Files waiting for recovery with elevated priority
+mds_cache/recovery_started | File recoveries started
+mds_cache/recovery_completed | File recoveries completed
+ | 
+mds_log/evadd | Events submitted
+mds_log/evex | Total expired events
+mds_log/evtrm | Trimmed events
+mds_log/ev | Events
+mds_log/evexg | Expiring events
+mds_log/evexd | Current expired events
+mds_log/segadd | Segments added
+mds_log/segex | Total expired segments
+mds_log/segtrm | Trimmed segments
+mds_log/seg | Segments
+mds_log/segexg | Expiring segments
+mds_log/segexd | Current expired segments
+mds_log/expos | Journaler xpire position
+mds_log/wrpos | Journaler  write position
+mds_log/rdpos | Journaler  read position
+mds_log/jlat | Journaler flush latency
+ | 
+mds_mem/ino | Inodes
+mds_mem/ino+ | Inodes opened
+mds_mem/ino- | Inodes closed
+mds_mem/dir | Directories
+mds_mem/dir+ | Directories opened
+mds_mem/dir- | Directories closed
+mds_mem/dn | Dentries
+mds_mem/dn+ | Dentries opened
+mds_mem/dn- | Dentries closed
+mds_mem/cap | Capabilities
+mds_mem/cap+ | Capabilities added
+mds_mem/cap- | Capabilities removed
+mds_mem/rss | RSS
+mds_mem/heap | Heap size
+mds_mem/malloc | Malloc size
+mds_mem/buf | Buffer size
+ | 
+mds_server/handle_client_request | Client requests
+mds_server/handle_slave_request | Slave requests
+mds_server/handle_client_session | Client session messages
+mds_server/dispatch_client_request | Client requests dispatched
+mds_server/dispatch_server_request | Server requests dispatched
+ | 
+objecter/op_active | Operations active
+objecter/op_laggy | Laggy operations
+objecter/op_send | Sent operations
+objecter/op_send_bytes | Sent data
+objecter/op_resend | Resent operations
+objecter/op_ack | Commit callbacks
+objecter/op_commit | Operation commits
+objecter/op | Operations
+objecter/op_r | Read operations
+objecter/op_w | Write operations
+objecter/op_rmw | Read-modify-write operations
+objecter/op_pg | PG operation
+objecter/osdop_stat | Stat operations
+objecter/osdop_create | Create object operations
+objecter/osdop_read | Read operations
+objecter/osdop_write | Write operations
+objecter/osdop_writefull | Write full object operations
+objecter/osdop_append | Append operation
+objecter/osdop_zero | Set object to zero operations
+objecter/osdop_truncate | Truncate object operations
+objecter/osdop_delete | Delete object operations
+objecter/osdop_mapext | Map extent operations
+objecter/osdop_sparse_read | Sparse read operations
+objecter/osdop_clonerange | Clone range operations
+objecter/osdop_getxattr | Get xattr operations
+objecter/osdop_setxattr | Set xattr operations
+objecter/osdop_cmpxattr | Xattr comparison operations
+objecter/osdop_rmxattr | Remove xattr operations
+objecter/osdop_resetxattrs | Reset xattr operations
+objecter/osdop_tmap_up | TMAP update operations
+objecter/osdop_tmap_put | TMAP put operations
+objecter/osdop_tmap_get | TMAP get operations
+objecter/osdop_call | Call (execute) operations
+objecter/osdop_watch | Watch by object operations
+objecter/osdop_notify | Notify about object operations
+objecter/osdop_src_cmpxattr | Extended attribute comparison in multi operations
+objecter/osdop_pgls | [No description available]
+objecter/osdop_pgls_filter | [No description available]
+objecter/osdop_other | Other operations
+objecter/linger_active | Active lingering operations
+objecter/linger_send | Sent lingering operations
+objecter/linger_resend | Resent lingering operations
+objecter/linger_ping | Sent pings to lingering operations
+objecter/poolop_active | Active pool operations
+objecter/poolop_send | Sent pool operations
+objecter/poolop_resend | Resent pool operations
+objecter/poolstat_active | Active get pool stat operations
+objecter/poolstat_send | Pool stat operations sent
+objecter/poolstat_resend | Resent pool stats
+objecter/statfs_active | Statfs operations
+objecter/statfs_send | Sent FS stats
+objecter/statfs_resend | Resent FS stats
+objecter/command_active | Active commands
+objecter/command_send | Sent commands
+objecter/command_resend | Resent commands
+objecter/map_epoch | OSD map epoch
+objecter/map_full | Full OSD maps received
+objecter/map_inc | Incremental OSD maps received
+objecter/osd_sessions | Open sessions
+objecter/osd_session_open | Sessions opened
+objecter/osd_session_close | Sessions closed
+objecter/osd_laggy | Laggy OSD sessions
+objecter/omap_wr | OSD OMAP write operations
+objecter/omap_rd | OSD OMAP read operations
+objecter/omap_del | OSD OMAP delete operations
+ | 
+throttle-msgr_dispatch_throttler-mds/val | Currently available throttle
+throttle-msgr_dispatch_throttler-mds/max | Max value for throttle
+throttle-msgr_dispatch_throttler-mds/get | Gets
+throttle-msgr_dispatch_throttler-mds/get_sum | Got data
+throttle-msgr_dispatch_throttler-mds/get_or_fail_fail | Get blocked during get_or_fail
+throttle-msgr_dispatch_throttler-mds/get_or_fail_success | Successful get during get_or_fail
+throttle-msgr_dispatch_throttler-mds/take | Takes
+throttle-msgr_dispatch_throttler-mds/take_sum | Taken data
+throttle-msgr_dispatch_throttler-mds/put | Puts
+throttle-msgr_dispatch_throttler-mds/put_sum | Put data
+throttle-msgr_dispatch_throttler-mds/wait/avgcount | Waiting latency
+throttle-msgr_dispatch_throttler-mds/wait/sum | Waiting latency
+ | 
+throttle-objecter_bytes/val | Currently available throttle
+throttle-objecter_bytes/max | Max value for throttle
+throttle-objecter_bytes/get | Gets
+throttle-objecter_bytes/get_sum | Got data
+throttle-objecter_bytes/get_or_fail_fail | Get blocked during get_or_fail
+throttle-objecter_bytes/get_or_fail_success | Successful get during get_or_fail
+throttle-objecter_bytes/take | Takes
+throttle-objecter_bytes/take_sum | Taken data
+throttle-objecter_bytes/put | Puts
+throttle-objecter_bytes/put_sum | Put data
+throttle-objecter_bytes/wait/avgcount | Waiting latency
+throttle-objecter_bytes/wait/sum | Waiting latency
+ | 
+throttle-objecter_ops/val | Currently available throttle
+throttle-objecter_ops/max | Max value for throttle
+throttle-objecter_ops/get | Gets
+throttle-objecter_ops/get_sum | Got data
+throttle-objecter_ops/get_or_fail_fail | Get blocked during get_or_fail
+throttle-objecter_ops/get_or_fail_success | Successful get during get_or_fail
+throttle-objecter_ops/take | Takes
+throttle-objecter_ops/take_sum | Taken data
+throttle-objecter_ops/put | Puts
+throttle-objecter_ops/put_sum | Put data
+throttle-objecter_ops/wait/avgcount | Waiting latency
+throttle-objecter_ops/wait/sum | Waiting latency

--- a/MON_PERFCNT.md
+++ b/MON_PERFCNT.md
@@ -1,0 +1,159 @@
+<!--
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+## Pulse Ceph Perf Counters Collector Plugin
+
+
+# Ceph MON Perf Counters
+
+Prefix: /intel/storage/ceph/{mon_daemon_name}/
+
+Metrics | Description
+------------ | -------------
+cluster/num_mon | Monitors
+cluster/num_mon_quorum | Monitors in quorum
+cluster/num_osd | OSDs
+cluster/num_osd_up | OSDs that are up
+cluster/num_osd_in | OSD in state \in\ (they are in cluster)
+cluster/osd_epoch | Current epoch of OSD map
+cluster/osd_bytes | Total capacity of cluster
+cluster/osd_bytes_used | Used space
+cluster/osd_bytes_avail | Available space
+cluster/num_pool | Pools
+cluster/num_pg | Placement groups
+cluster/num_pg_active_clean | Placement groups in active+clean state
+cluster/num_pg_active | Placement groups in active state
+cluster/num_pg_peering | Placement groups in peering state
+cluster/num_object | Objects
+cluster/num_object_degraded | Degraded (missing replicas) objects
+cluster/num_object_misplaced | Misplaced (wrong location in the cluster) objects
+cluster/num_object_unfound | Unfound objects
+cluster/num_bytes | Size of all objects
+cluster/num_mds_up | MDSs that are up
+cluster/num_mds_in | MDS in state \in\ (they are in cluster)
+cluster/num_mds_failed | Failed MDS
+cluster/mds_epoch | Current epoch of MDS map
+ | 
+finisher-monstore/queue_len | Length of queue in finisher-monstore
+ | 
+leveldb/leveldb_get | Gets
+leveldb/leveldb_transaction | Transactions
+leveldb/leveldb_get_latency | Get Latency
+leveldb/leveldb_submit_latency | Submit Latency
+leveldb/leveldb_submit_sync_latency | Submit Sync Latency
+leveldb/leveldb_compact | Compactions
+leveldb/leveldb_compact_range | Compactions by range
+leveldb/leveldb_compact_queue_merge | Mergings of ranges in compaction queue
+leveldb/leveldb_compact_queue_len | Length of compaction queue
+ | 
+mon/num_sessions | Open sessions
+mon/session_add | Created sessions
+mon/session_rm | Removed sessions
+mon/session_trim | Trimmed sessions
+mon/num_elections | Elections participated in
+mon/election_call | Elections started
+mon/election_win | Elections won
+mon/election_lose | Elections lost
+ | 
+paxos/start_leader | Starts in leader role
+paxos/start_peon | Starts in peon role
+paxos/restart | Restarts
+paxos/refresh | Refreshes
+paxos/refresh_latency/avgcount | Refresh latency
+paxos/refresh_latency/sum | Refresh latency
+paxos/begin | Started and handled begins
+paxos/begin_keys/avgcount | Keys in transaction on begin
+paxos/begin_keys/sum | Keys in transaction on begin
+paxos/begin_bytes/avgcount | Data in transaction on begin
+paxos/begin_bytes/sum | Data in transaction on begin
+paxos/begin_latency/avgcount | Latency of begin operation
+paxos/begin_latency/sum | Latency of begin operation
+paxos/commit | Commits
+paxos/commit_keys/avgcount | Keys in transaction on commit
+paxos/commit_keys/sum | Keys in transaction on commit
+paxos/commit_bytes/avgcount | Data in transaction on commit
+paxos/commit_bytes/sum | Data in transaction on commit
+paxos/commit_latency/avgcount | Commit latency
+paxos/commit_latency/sum | Commit latency
+paxos/collect | Peon collects
+paxos/collect_keys/avgcount | Keys in transaction on peon collect
+paxos/collect_keys/sum | Keys in transaction on peon collect
+paxos/collect_bytes/avgcount | Data in transaction on peon collect
+paxos/collect_bytes/sum | Data in transaction on peon collect
+paxos/collect_latency/avgcount | Peon collect latency
+paxos/collect_latency/sum | Peon collect latency
+paxos/collect_uncommitted | Uncommitted values in started and handled collects
+paxos/collect_timeout | Collect timeouts
+paxos/accept_timeout | Accept timeouts
+paxos/lease_ack_timeout | Lease acknowledgement timeouts
+paxos/lease_timeout | Lease timeouts
+paxos/store_state | Store a shared state on disk
+paxos/store_state_keys/avgcount | Keys in transaction in stored state
+paxos/store_state_keys/sum | Keys in transaction in stored state
+paxos/store_state_bytes/avgcount | Data in transaction in stored state
+paxos/store_state_bytes/sum | Data in transaction in stored state
+paxos/store_state_latency/avgcount | Storing state latency
+paxos/store_state_latency/sum | Storing state latency
+paxos/share_state | Sharings of state
+paxos/share_state_keys/avgcount | Keys in shared state
+paxos/share_state_keys/sum | Keys in shared state
+paxos/share_state_bytes/avgcount | Data in shared state
+paxos/share_state_bytes/sum | Data in shared state
+paxos/new_pn | New proposal number queries
+paxos/new_pn_latency/avgcount | New proposal number getting latency
+paxos/new_pn_latency/sum | New proposal number getting latency
+ | 
+throttle-mon_client_bytes/val | Currently available throttle
+throttle-mon_client_bytes/max | Max value for throttle
+throttle-mon_client_bytes/get | Gets
+throttle-mon_client_bytes/get_sum | Got data
+throttle-mon_client_bytes/get_or_fail_fail | Get blocked during get_or_fail
+throttle-mon_client_bytes/get_or_fail_success | Successful get during get_or_fail
+throttle-mon_client_bytes/take | Takes
+throttle-mon_client_bytes/take_sum | Taken data
+throttle-mon_client_bytes/put | Puts
+throttle-mon_client_bytes/put_sum | Put data
+throttle-mon_client_bytes/wait/avgcount | Waiting latency
+throttle-mon_client_bytes/wait/sum | Waiting latency
+ | 
+throttle-mon_daemon_bytes/val | Currently available throttle
+throttle-mon_daemon_bytes/max | Max value for throttle
+throttle-mon_daemon_bytes/get | Gets
+throttle-mon_daemon_bytes/get_sum | Got data
+throttle-mon_daemon_bytes/get_or_fail_fail | Get blocked during get_or_fail
+throttle-mon_daemon_bytes/get_or_fail_success | Successful get during get_or_fail
+throttle-mon_daemon_bytes/take | Takes
+throttle-mon_daemon_bytes/take_sum | Taken data
+throttle-mon_daemon_bytes/put | Puts
+throttle-mon_daemon_bytes/put_sum | Put data
+throttle-mon_daemon_bytes/wait/avgcount | Waiting latency
+throttle-mon_daemon_bytes/wait/sum | Waiting latency
+ | 
+throttle-msgr_dispatch_throttler-mon/val | Currently available throttle
+throttle-msgr_dispatch_throttler-mon/max | Max value for throttle
+throttle-msgr_dispatch_throttler-mon/get | Gets
+throttle-msgr_dispatch_throttler-mon/get_sum | Got data
+throttle-msgr_dispatch_throttler-mon/get_or_fail_fail | Get blocked during get_or_fail
+throttle-msgr_dispatch_throttler-mon/get_or_fail_success | Successful get during get_or_fail
+throttle-msgr_dispatch_throttler-mon/take | Takes
+throttle-msgr_dispatch_throttler-mon/take_sum | Taken data
+throttle-msgr_dispatch_throttler-mon/put | Puts
+throttle-msgr_dispatch_throttler-mon/put_sum | Put data
+throttle-msgr_dispatch_throttler-mon/wait/avgcount | Waiting latency
+throttle-msgr_dispatch_throttler-mon/wait/sum | Waiting latency

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+default:
+	$(MAKE) deps
+	$(MAKE) all
+deps:
+	bash -c "godep restore"
+test:
+	bash -c "./scripts/test.sh $(TEST)"
+check:
+	$(MAKE) test
+all:
+	bash -c "./scripts/build.sh $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))"

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Apache pulse
+Copyright 2015 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/OSD_PERFCNT.md
+++ b/OSD_PERFCNT.md
@@ -1,0 +1,488 @@
+<!--
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+## Pulse Ceph Perf Counters Collector Plugin
+
+
+# Ceph OSD Perf Counters
+
+Prefix: /intel/storage/ceph/{osd_daemon_name}/
+
+Metrics | Description
+------------ | -------------
+WBThrottle/bytes_dirtied | Dirty data 
+WBThrottle/bytes_wb | Written data 
+WBThrottle/ios_dirtied | Dirty operations 
+WBThrottle/ios_wb | Written operations 
+WBThrottle/inodes_dirtied | Entries waiting for write 
+WBThrottle/inodes_wb | Written entries 
+ | 
+filestore/journal_queue_max_ops | Max operations in journal queue 
+filestore/journal_queue_ops | Operations in journal queue 
+filestore/journal_ops | Total journal entries written 
+filestore/journal_queue_max_bytes | Max data in journal queue 
+filestore/journal_queue_bytes | Size of journal queue 
+filestore/journal_bytes | Total operations size in journal 
+filestore/journal_latency/avgcount | Average journal queue completing latency 
+filestore/journal_latency/sum | Average journal queue completing latency 
+filestore/journal_wr | Journal write IOs 
+filestore/journal_wr_bytes/avgcount | Journal data written 
+filestore/journal_wr_bytes/sum | Journal data written 
+filestore/journal_full | Journal writes while full 
+filestore/committing | Is currently committing 
+filestore/commitcycle | Commit cycles 
+filestore/commitcycle_interval/avgcount | Average interval between commits 
+filestore/commitcycle_interval/sum | Average interval between commits 
+filestore/commitcycle_latency/avgcount | Average latency of commit 
+filestore/commitcycle_latency/sum | Average latency of commit 
+filestore/op_queue_max_ops | Max operations in writing to FS queue 
+filestore/op_queue_ops | Operations in writing to FS queue 
+filestore/ops | Operations written to store 
+filestore/op_queue_max_bytes | Max data in writing to FS queue 
+filestore/op_queue_bytes | Size of writing to FS queue 
+filestore/bytes | Data written to store 
+filestore/apply_latency/avgcount | Apply latency 
+filestore/apply_latency/sum | Apply latency 
+filestore/queue_transaction_latency_avg/avgcount | Store operation queue latency 
+filestore/queue_transaction_latency_avg/sum | Store operation queue latency 
+ | 
+leveldb/leveldb_get | Gets 
+leveldb/leveldb_transaction | Transactions 
+leveldb/leveldb_get_latency | Get Latency 
+leveldb/leveldb_submit_latency | Submit Latency 
+leveldb/leveldb_submit_sync_latency | Submit Sync Latency 
+leveldb/leveldb_compact | Compactions 
+leveldb/leveldb_compact_range | Compactions by range 
+leveldb/leveldb_compact_queue_merge | Mergings of ranges in compaction queue 
+leveldb/leveldb_compact_queue_len | Length of compaction queue 
+ | 
+mutex-FileJournal::completions_lock/wait/avgcount | Average time of mutex in locked state 
+mutex-FileJournal::completions_lock/wait/sum | Average time of mutex in locked state 
+mutex-FileJournal::finisher_lock/wait/avgcount | Average time of mutex in locked state 
+mutex-FileJournal::finisher_lock/wait/sum | Average time of mutex in locked state 
+mutex-FileJournal::write_lock/wait/avgcount | Average time of mutex in locked state 
+mutex-FileJournal::write_lock/wait/sum | Average time of mutex in locked state 
+mutex-FileJournal::writeq_lock/wait/avgcount | Average time of mutex in locked state 
+mutex-FileJournal::writeq_lock/wait/sum | Average time of mutex in locked state 
+mutex-JOS::ApplyManager::apply_lock/wait/avgcount | Average time of mutex in locked state 
+mutex-JOS::ApplyManager::apply_lock/wait/sum | Average time of mutex in locked state 
+mutex-JOS::ApplyManager::com_lock/wait/avgcount | Average time of mutex in locked state 
+mutex-JOS::ApplyManager::com_lock/wait/sum | Average time of mutex in locked state 
+mutex-JOS::SubmitManager::lock/wait/avgcount | Average time of mutex in locked state 
+mutex-JOS::SubmitManager::lock/wait/sum | Average time of mutex in locked state 
+mutex-WBThrottle::lock/wait/avgcount | Average time of mutex in locked state 
+mutex-WBThrottle::lock/wait/sum | Average time of mutex in locked state 
+ | 
+objecter/op_active | Operations active 
+objecter/op_laggy | Laggy operations 
+objecter/op_send | Sent operations 
+objecter/op_send_bytes | Sent data 
+objecter/op_resend | Resent operations 
+objecter/op_ack | Commit callbacks 
+objecter/op_commit | Operation commits 
+objecter/op | Operations 
+objecter/op_r | Read operations 
+objecter/op_w | Write operations 
+objecter/op_rmw | Read-modify-write operations 
+objecter/op_pg | PG operation 
+objecter/osdop_stat | Stat operations 
+objecter/osdop_create | Create object operations 
+objecter/osdop_read | Read operations 
+objecter/osdop_write | Write operations 
+objecter/osdop_writefull | Write full object operations 
+objecter/osdop_append | Append operation 
+objecter/osdop_zero | Set object to zero operations 
+objecter/osdop_truncate | Truncate object operations 
+objecter/osdop_delete | Delete object operations 
+objecter/osdop_mapext | Map extent operations 
+objecter/osdop_sparse_read | Sparse read operations 
+objecter/osdop_clonerange | Clone range operations 
+objecter/osdop_getxattr | Get xattr operations 
+objecter/osdop_setxattr | Set xattr operations 
+objecter/osdop_cmpxattr | Xattr comparison operations 
+objecter/osdop_rmxattr | Remove xattr operations 
+objecter/osdop_resetxattrs | Reset xattr operations 
+objecter/osdop_tmap_up | TMAP update operations 
+objecter/osdop_tmap_put | TMAP put operations 
+objecter/osdop_tmap_get | TMAP get operations 
+objecter/osdop_call | Call (execute) operations 
+objecter/osdop_watch | Watch by object operations 
+objecter/osdop_notify | Notify about object operations 
+objecter/osdop_src_cmpxattr | Extended attribute comparison in multi operations 
+objecter/osdop_pgls |  [No description available]
+objecter/osdop_pgls_filter |  [No description available]
+objecter/osdop_other | Other operations 
+objecter/linger_active | Active lingering operations 
+objecter/linger_send | Sent lingering operations 
+objecter/linger_resend | Resent lingering operations 
+objecter/linger_ping | Sent pings to lingering operations 
+objecter/poolop_active | Active pool operations 
+objecter/poolop_send | Sent pool operations 
+objecter/poolop_resend | Resent pool operations 
+objecter/poolstat_active | Active get pool stat operations 
+objecter/poolstat_send | Pool stat operations sent 
+objecter/poolstat_resend | Resent pool stats 
+objecter/statfs_active | Statfs operations 
+objecter/statfs_send | Sent FS stats 
+objecter/statfs_resend | Resent FS stats 
+objecter/command_active | Active commands 
+objecter/command_send | Sent commands 
+objecter/command_resend | Resent commands 
+objecter/map_epoch | OSD map epoch 
+objecter/map_full | Full OSD maps received 
+objecter/map_inc | Incremental OSD maps received 
+objecter/osd_sessions | Open sessions 
+objecter/osd_session_open | Sessions opened 
+objecter/osd_session_close | Sessions closed 
+objecter/osd_laggy | Laggy OSD sessions 
+objecter/omap_wr | OSD OMAP write operations 
+objecter/omap_rd | OSD OMAP read operations 
+objecter/omap_del | OSD OMAP delete operations 
+ | 
+osd/op_wip | Replication operations currently being processed (primary) 
+osd/op | Client operations 
+osd/op_in_bytes | Client operations total write size 
+osd/op_out_bytes | Client operations total read size 
+osd/op_latency/avgcount | Latency of client operations (including queue time) 
+osd/op_latency/sum | Latency of client operations (including queue time) 
+osd/op_process_latency/avgcount | Latency of client operations (excluding queue time) 
+osd/op_process_latency/sum | Latency of client operations (excluding queue time) 
+osd/op_r | Client read operations 
+osd/op_r_out_bytes | Client data read 
+osd/op_r_latency/avgcount | Latency of read operation (including queue time) 
+osd/op_r_latency/sum | Latency of read operation (including queue time) 
+osd/op_r_process_latency/avgcount | Latency of read operation (excluding queue time) 
+osd/op_r_process_latency/sum | Latency of read operation (excluding queue time) 
+osd/op_w | Client write operations 
+osd/op_w_in_bytes | Client data written 
+osd/op_w_rlat/avgcount | Client write operation readable\/applied latency 
+osd/op_w_rlat/sum | Client write operation readable\/applied latency 
+osd/op_w_latency/avgcount | Latency of write operation (including queue time) 
+osd/op_w_latency/sum | Latency of write operation (including queue time) 
+osd/op_w_process_latency/avgcount | Latency of write operation (excluding queue time) 
+osd/op_w_process_latency/sum | Latency of write operation (excluding queue time) 
+osd/op_rw | Client read-modify-write operations 
+osd/op_rw_in_bytes | Client read-modify-write operations write in 
+osd/op_rw_out_bytes | Client read-modify-write operations read out  
+osd/op_rw_rlat/avgcount | Client read-modify-write operation readable\/applied latency 
+osd/op_rw_rlat/sum | Client read-modify-write operation readable\/applied latency 
+osd/op_rw_latency/avgcount | Latency of read-modify-write operation (including queue time) 
+osd/op_rw_latency/sum | Latency of read-modify-write operation (including queue time) 
+osd/op_rw_process_latency/avgcount | Latency of read-modify-write operation (excluding queue time) 
+osd/op_rw_process_latency/sum | Latency of read-modify-write operation (excluding queue time) 
+osd/subop | Suboperations 
+osd/subop_in_bytes | Suboperations total size 
+osd/subop_latency/avgcount | Suboperations latency 
+osd/subop_latency/sum | Suboperations latency 
+osd/subop_w | Replicated writes 
+osd/subop_w_in_bytes | Replicated written data size 
+osd/subop_w_latency/avgcount | Replicated writes latency 
+osd/subop_w_latency/sum | Replicated writes latency 
+osd/subop_pull | Suboperations pull requests 
+osd/subop_pull_latency/avgcount | Suboperations pull latency 
+osd/subop_pull_latency/sum | Suboperations pull latency 
+osd/subop_push | Suboperations push messages 
+osd/subop_push_in_bytes | Suboperations pushed size 
+osd/subop_push_latency/avgcount | Suboperations push latency 
+osd/subop_push_latency/sum | Suboperations push latency 
+osd/pull | Pull requests sent 
+osd/push | Push messages sent 
+osd/push_out_bytes | Pushed size 
+osd/push_in | Inbound push messages 
+osd/push_in_bytes | Inbound pushed size 
+osd/recovery_ops | Started recovery operations 
+osd/loadavg | CPU load 
+osd/buffer_bytes | Total allocated buffer size 
+osd/numpg | Placement groups 
+osd/numpg_primary | Placement groups for which this osd is primary 
+osd/numpg_replica | Placement groups for which this osd is replica 
+osd/numpg_stray | Placement groups ready to be deleted from this osd 
+osd/heartbeat_to_peers | Heartbeat (ping) peers we send to 
+osd/heartbeat_from_peers | Heartbeat (ping) peers we recv from 
+osd/map_messages | OSD map messages 
+osd/map_message_epochs | OSD map epochs 
+osd/map_message_epoch_dups | OSD map duplicates 
+osd/messages_delayed_for_map | Operations waiting for OSD map 
+osd/stat_bytes | OSD size 
+osd/stat_bytes_used | Used space 
+osd/stat_bytes_avail | Available space 
+osd/copyfrom | Rados \"copy-from\" operations
+osd/tier_promote | Tier promotions 
+osd/tier_flush | Tier flushes 
+osd/tier_flush_fail | Failed tier flushes 
+osd/tier_try_flush | Tier flush attempts 
+osd/tier_try_flush_fail | Failed tier flush attempts 
+osd/tier_evict | Tier evictions 
+osd/tier_whiteout | Tier whiteouts 
+osd/tier_dirty | Dirty tier flag set 
+osd/tier_clean | Dirty tier flag cleaned 
+osd/tier_delay | Tier delays (agent waiting) 
+osd/tier_proxy_read | Tier proxy reads 
+osd/tier_proxy_write | Tier proxy writes 
+osd/agent_wake | Tiering agent wake up 
+osd/agent_skip | Objects skipped by agent 
+osd/agent_flush | Tiering agent flushes 
+osd/agent_evict | Tiering agent evictions 
+osd/object_ctx_cache_hit | Object context cache hits 
+osd/object_ctx_cache_total | Object context cache lookups 
+osd/op_cache_hit | 
+osd/op_tier_flush_lat | Object flush latency 
+osd/op_tier_promote_lat | Object promote latency 
+osd/op_tier_r_lat | Object proxy read latency 
+ | 
+recoverystate_perf/initial_latency/avgcount | Initial recovery state latency 
+recoverystate_perf/initial_latency/sum | Initial recovery state latency 
+recoverystate_perf/started_latency/avgcount | Started recovery state latency 
+recoverystate_perf/started_latency/sum | Started recovery state latency 
+recoverystate_perf/reset_latency/avgcount | Reset recovery state latency 
+recoverystate_perf/reset_latency/sum | Reset recovery state latency 
+recoverystate_perf/start_latency/avgcount | Start recovery state latency 
+recoverystate_perf/start_latency/sum | Start recovery state latency 
+recoverystate_perf/primary_latency/avgcount | Primary recovery state latency 
+recoverystate_perf/primary_latency/sum | Primary recovery state latency 
+recoverystate_perf/peering_latency/avgcount | Peering recovery state latency 
+recoverystate_perf/peering_latency/sum | Peering recovery state latency 
+recoverystate_perf/backfilling_latency/avgcount | Backfilling recovery state latency 
+recoverystate_perf/backfilling_latency/sum | Backfilling recovery state latency 
+recoverystate_perf/waitremotebackfillreserved_latency/avgcount | Wait remote backfill reserved recovery state latency 
+recoverystate_perf/waitremotebackfillreserved_latency/sum | Wait remote backfill reserved recovery state latency 
+recoverystate_perf/waitlocalbackfillreserved_latency/avgcount | Wait local backfill reserved recovery state latency 
+recoverystate_perf/waitlocalbackfillreserved_latency/sum | Wait local backfill reserved recovery state latency 
+recoverystate_perf/notbackfilling_latency/avgcount | Notbackfilling recovery state latency 
+recoverystate_perf/notbackfilling_latency/sum | Notbackfilling recovery state latency 
+recoverystate_perf/repnotrecovering_latency/avgcount | Repnotrecovering recovery state latency 
+recoverystate_perf/repnotrecovering_latency/sum | Repnotrecovering recovery state latency 
+recoverystate_perf/repwaitrecoveryreserved_latency/avgcount | Rep wait recovery reserved recovery state latency 
+recoverystate_perf/repwaitrecoveryreserved_latency/sum | Rep wait recovery reserved recovery state latency 
+recoverystate_perf/repwaitbackfillreserved_latency/avgcount | Rep wait backfill reserved recovery state latency 
+recoverystate_perf/repwaitbackfillreserved_latency/sum | Rep wait backfill reserved recovery state latency 
+recoverystate_perf/RepRecovering_latency/avgcount | RepRecovering recovery state latency 
+recoverystate_perf/RepRecovering_latency/sum | RepRecovering recovery state latency 
+recoverystate_perf/activating_latency/avgcount | Activating recovery state latency 
+recoverystate_perf/activating_latency/sum | Activating recovery state latency 
+recoverystate_perf/waitlocalrecoveryreserved_latency/avgcount | Wait local recovery reserved recovery state latency 
+recoverystate_perf/waitlocalrecoveryreserved_latency/sum | Wait local recovery reserved recovery state latency 
+recoverystate_perf/waitremoterecoveryreserved_latency/avgcount | Wait remote recovery reserved recovery state latency 
+recoverystate_perf/waitremoterecoveryreserved_latency/sum | Wait remote recovery reserved recovery state latency 
+recoverystate_perf/recovering_latency/avgcount | Recovering recovery state latency 
+recoverystate_perf/recovering_latency/sum | Recovering recovery state latency 
+recoverystate_perf/recovered_latency/avgcount | Recovered recovery state latency 
+recoverystate_perf/recovered_latency/sum | Recovered recovery state latency 
+recoverystate_perf/clean_latency/avgcount | Clean recovery state latency 
+recoverystate_perf/clean_latency/sum | Clean recovery state latency 
+recoverystate_perf/active_latency/avgcount | Active recovery state latency 
+recoverystate_perf/active_latency/sum | Active recovery state latency 
+recoverystate_perf/replicaactive_latency/avgcount | Replicaactive recovery state latency 
+recoverystate_perf/replicaactive_latency/sum | Replicaactive recovery state latency 
+recoverystate_perf/stray_latency/avgcount | Stray recovery state latency 
+recoverystate_perf/stray_latency/sum | Stray recovery state latency 
+recoverystate_perf/getinfo_latency/avgcount | Getinfo recovery state latency 
+recoverystate_perf/getinfo_latency/sum | Getinfo recovery state latency 
+recoverystate_perf/getlog_latency/avgcount | Getlog recovery state latency 
+recoverystate_perf/getlog_latency/sum | Getlog recovery state latency 
+recoverystate_perf/waitactingchange_latency/avgcount | Waitactingchange recovery state latency 
+recoverystate_perf/waitactingchange_latency/sum | Waitactingchange recovery state latency 
+recoverystate_perf/incomplete_latency/avgcount | Incomplete recovery state latency 
+recoverystate_perf/incomplete_latency/sum | Incomplete recovery state latency 
+recoverystate_perf/getmissing_latency/avgcount | Getmissing recovery state latency 
+recoverystate_perf/getmissing_latency/sum | Getmissing recovery state latency 
+recoverystate_perf/waitupthru_latency/avgcount | Waitupthru recovery state latency 
+recoverystate_perf/waitupthru_latency/sum | Waitupthru recovery state latency 
+ | 
+throttle-filestore_bytes/val | Currently available throttle 
+throttle-filestore_bytes/max | Max value for throttle 
+throttle-filestore_bytes/get | Gets 
+throttle-filestore_bytes/get_sum | Got data 
+throttle-filestore_bytes/get_or_fail_fail | Get blocked during get_or_fail 
+throttle-filestore_bytes/get_or_fail_success | Successful get during get_or_fail 
+throttle-filestore_bytes/take | Takes 
+throttle-filestore_bytes/take_sum | Taken data 
+throttle-filestore_bytes/put | Puts 
+throttle-filestore_bytes/put_sum | Put data 
+throttle-filestore_bytes/wait/avgcount | Waiting latency 
+throttle-filestore_bytes/wait/sum | Waiting latency 
+ | 
+throttle-filestore_ops/val | Currently available throttle 
+throttle-filestore_ops/max | Max value for throttle 
+throttle-filestore_ops/get | Gets 
+throttle-filestore_ops/get_sum | Got data 
+throttle-filestore_ops/get_or_fail_fail | Get blocked during get_or_fail 
+throttle-filestore_ops/get_or_fail_success | Successful get during get_or_fail 
+throttle-filestore_ops/take | Takes 
+throttle-filestore_ops/take_sum | Taken data 
+throttle-filestore_ops/put | Puts 
+throttle-filestore_ops/put_sum | Put data 
+throttle-filestore_ops/wait/avgcount | Waiting latency 
+throttle-filestore_ops/wait/sum | Waiting latency 
+ | 
+throttle-journal_bytes/val | Currently available throttle 
+throttle-journal_bytes/max | Max value for throttle 
+throttle-journal_bytes/get | Gets 
+throttle-journal_bytes/get_sum | Got data 
+throttle-journal_bytes/get_or_fail_fail | Get blocked during get_or_fail 
+throttle-journal_bytes/get_or_fail_success | Successful get during get_or_fail 
+throttle-journal_bytes/take | Takes 
+throttle-journal_bytes/take_sum | Taken data 
+throttle-journal_bytes/put | Puts 
+throttle-journal_bytes/put_sum | Put data 
+throttle-journal_bytes/wait/avgcount | Waiting latency 
+throttle-journal_bytes/wait/sum | Waiting latency 
+ | 
+throttle-journal_ops/val | Currently available throttle 
+throttle-journal_ops/max | Max value for throttle 
+throttle-journal_ops/get | Gets 
+throttle-journal_ops/get_sum | Got data 
+throttle-journal_ops/get_or_fail_fail | Get blocked during get_or_fail 
+throttle-journal_ops/get_or_fail_success | Successful get during get_or_fail 
+throttle-journal_ops/take | Takes 
+throttle-journal_ops/take_sum | Taken data 
+throttle-journal_ops/put | Puts 
+throttle-journal_ops/put_sum | Put data 
+throttle-journal_ops/wait/avgcount | Waiting latency 
+throttle-journal_ops/wait/sum | Waiting latency 
+ | 
+throttle-msgr_dispatch_throttler-client/val | Currently available throttle 
+throttle-msgr_dispatch_throttler-client/max | Max value for throttle 
+throttle-msgr_dispatch_throttler-client/get | Gets 
+throttle-msgr_dispatch_throttler-client/get_sum | Got data 
+throttle-msgr_dispatch_throttler-client/get_or_fail_fail | Get blocked during get_or_fail 
+throttle-msgr_dispatch_throttler-client/get_or_fail_success | Successful get during get_or_fail 
+throttle-msgr_dispatch_throttler-client/take | Takes 
+throttle-msgr_dispatch_throttler-client/take_sum | Taken data 
+throttle-msgr_dispatch_throttler-client/put | Puts 
+throttle-msgr_dispatch_throttler-client/put_sum | Put data 
+throttle-msgr_dispatch_throttler-client/wait/avgcount | Waiting latency 
+throttle-msgr_dispatch_throttler-client/wait/sum | Waiting latency 
+ | 
+throttle-msgr_dispatch_throttler-cluster/val | Currently available throttle 
+throttle-msgr_dispatch_throttler-cluster/max | Max value for throttle 
+throttle-msgr_dispatch_throttler-cluster/get | Gets 
+throttle-msgr_dispatch_throttler-cluster/get_sum | Got data 
+throttle-msgr_dispatch_throttler-cluster/get_or_fail_fail | Get blocked during get_or_fail 
+throttle-msgr_dispatch_throttler-cluster/get_or_fail_success | Successful get during get_or_fail 
+throttle-msgr_dispatch_throttler-cluster/take | Takes 
+throttle-msgr_dispatch_throttler-cluster/take_sum | Taken data 
+throttle-msgr_dispatch_throttler-cluster/put | Puts 
+throttle-msgr_dispatch_throttler-cluster/put_sum | Put data 
+throttle-msgr_dispatch_throttler-cluster/wait/avgcount | Waiting latency 
+throttle-msgr_dispatch_throttler-cluster/wait/sum | Waiting latency 
+ | 
+throttle-msgr_dispatch_throttler-hb_back_server/val | Currently available throttle 
+throttle-msgr_dispatch_throttler-hb_back_server/max | Max value for throttle 
+throttle-msgr_dispatch_throttler-hb_back_server/get | Gets 
+throttle-msgr_dispatch_throttler-hb_back_server/get_sum | Got data 
+throttle-msgr_dispatch_throttler-hb_back_server/get_or_fail_fail | Get blocked during get_or_fail 
+throttle-msgr_dispatch_throttler-hb_back_server/get_or_fail_success | Successful get during get_or_fail 
+throttle-msgr_dispatch_throttler-hb_back_server/take | Takes 
+throttle-msgr_dispatch_throttler-hb_back_server/take_sum | Taken data 
+throttle-msgr_dispatch_throttler-hb_back_server/put | Puts 
+throttle-msgr_dispatch_throttler-hb_back_server/put_sum | Put data 
+throttle-msgr_dispatch_throttler-hb_back_server/wait/avgcount | Waiting latency 
+throttle-msgr_dispatch_throttler-hb_back_server/wait/sum | Waiting latency 
+ | 
+throttle-msgr_dispatch_throttler-hb_front_server/val | Currently available throttle 
+throttle-msgr_dispatch_throttler-hb_front_server/max | Max value for throttle 
+throttle-msgr_dispatch_throttler-hb_front_server/get | Gets 
+throttle-msgr_dispatch_throttler-hb_front_server/get_sum | Got data 
+throttle-msgr_dispatch_throttler-hb_front_server/get_or_fail_fail | Get blocked during get_or_fail 
+throttle-msgr_dispatch_throttler-hb_front_server/get_or_fail_success | Successful get during get_or_fail 
+throttle-msgr_dispatch_throttler-hb_front_server/take | Takes 
+throttle-msgr_dispatch_throttler-hb_front_server/take_sum | Taken data 
+throttle-msgr_dispatch_throttler-hb_front_server/put | Puts 
+throttle-msgr_dispatch_throttler-hb_front_server/put_sum | Put data 
+throttle-msgr_dispatch_throttler-hb_front_server/wait/avgcount | Waiting latency 
+throttle-msgr_dispatch_throttler-hb_front_server/wait/sum | Waiting latency 
+ | 
+throttle-msgr_dispatch_throttler-hbclient/val | Currently available throttle 
+throttle-msgr_dispatch_throttler-hbclient/max | Max value for throttle 
+throttle-msgr_dispatch_throttler-hbclient/get | Gets 
+throttle-msgr_dispatch_throttler-hbclient/get_sum | Got data 
+throttle-msgr_dispatch_throttler-hbclient/get_or_fail_fail | Get blocked during get_or_fail 
+throttle-msgr_dispatch_throttler-hbclient/get_or_fail_success | Successful get during get_or_fail 
+throttle-msgr_dispatch_throttler-hbclient/take | Takes 
+throttle-msgr_dispatch_throttler-hbclient/take_sum | Taken data 
+throttle-msgr_dispatch_throttler-hbclient/put | Puts 
+throttle-msgr_dispatch_throttler-hbclient/put_sum | Put data 
+throttle-msgr_dispatch_throttler-hbclient/wait/avgcount | Waiting latency 
+throttle-msgr_dispatch_throttler-hbclient/wait/sum | Waiting latency 
+ | 
+throttle-msgr_dispatch_throttler-ms_objecter/val | Currently available throttle 
+throttle-msgr_dispatch_throttler-ms_objecter/max | Max value for throttle 
+throttle-msgr_dispatch_throttler-ms_objecter/get | Gets 
+throttle-msgr_dispatch_throttler-ms_objecter/get_sum | Got data 
+throttle-msgr_dispatch_throttler-ms_objecter/get_or_fail_fail | Get blocked during get_or_fail 
+throttle-msgr_dispatch_throttler-ms_objecter/get_or_fail_success | Successful get during get_or_fail 
+throttle-msgr_dispatch_throttler-ms_objecter/take | Takes 
+throttle-msgr_dispatch_throttler-ms_objecter/take_sum | Taken data 
+throttle-msgr_dispatch_throttler-ms_objecter/put | Puts 
+throttle-msgr_dispatch_throttler-ms_objecter/put_sum | Put data 
+throttle-msgr_dispatch_throttler-ms_objecter/wait/avgcount | Waiting latency 
+throttle-msgr_dispatch_throttler-ms_objecter/wait/sum | Waiting latency 
+ | 
+throttle-objecter_bytes/val | Currently available throttle 
+throttle-objecter_bytes/max | Max value for throttle 
+throttle-objecter_bytes/get | Gets 
+throttle-objecter_bytes/get_sum | Got data 
+throttle-objecter_bytes/get_or_fail_fail | Get blocked during get_or_fail 
+throttle-objecter_bytes/get_or_fail_success | Successful get during get_or_fail 
+throttle-objecter_bytes/take | Takes 
+throttle-objecter_bytes/take_sum | Taken data 
+throttle-objecter_bytes/put | Puts 
+throttle-objecter_bytes/put_sum | Put data 
+throttle-objecter_bytes/wait/avgcount | Waiting latency 
+throttle-objecter_bytes/wait/sum | Waiting latency 
+ | 
+throttle-objecter_ops/val | Currently available throttle 
+throttle-objecter_ops/max | Max value for throttle 
+throttle-objecter_ops/get | Gets 
+throttle-objecter_ops/get_sum | Got data 
+throttle-objecter_ops/get_or_fail_fail | Get blocked during get_or_fail 
+throttle-objecter_ops/get_or_fail_success | Successful get during get_or_fail 
+throttle-objecter_ops/take | Takes 
+throttle-objecter_ops/take_sum | Taken data 
+throttle-objecter_ops/put | Puts 
+throttle-objecter_ops/put_sum | Put data 
+throttle-objecter_ops/wait/avgcount | Waiting latency 
+throttle-objecter_ops/wait/sum | Waiting latency 
+ | 
+throttle-osd_client_bytes/val | Currently available throttle 
+throttle-osd_client_bytes/max | Max value for throttle 
+throttle-osd_client_bytes/get | Gets 
+throttle-osd_client_bytes/get_sum | Got data 
+throttle-osd_client_bytes/get_or_fail_fail | Get blocked during get_or_fail 
+throttle-osd_client_bytes/get_or_fail_success | Successful get during get_or_fail 
+throttle-osd_client_bytes/take | Takes 
+throttle-osd_client_bytes/take_sum | Taken data 
+throttle-osd_client_bytes/put | Puts 
+throttle-osd_client_bytes/put_sum | Put data 
+throttle-osd_client_bytes/wait/avgcount | Waiting latency 
+throttle-osd_client_bytes/wait/sum | Waiting latency 
+ | 
+throttle-osd_client_messages/val | Currently available throttle 
+throttle-osd_client_messages/max | Max value for throttle 
+throttle-osd_client_messages/get | Gets 
+throttle-osd_client_messages/get_sum | Got data 
+throttle-osd_client_messages/get_or_fail_fail | Get blocked during get_or_fail 
+throttle-osd_client_messages/get_or_fail_success | Successful get during get_or_fail 
+throttle-osd_client_messages/take | Takes 
+throttle-osd_client_messages/take_sum | Taken data 
+throttle-osd_client_messages/put | Puts 
+throttle-osd_client_messages/put_sum | Put data 
+throttle-osd_client_messages/wait/avgcount | Waiting latency 
+throttle-osd_client_messages/wait/sum | Waiting latency 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,57 @@
-# pulse-plugin-collector-ceph
+<!--
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+	
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+## Pulse Ceph Perf Counters Collector Plugin
+
+# Description
+Collect Ceph performance counters from the Ceph Storage System for:
+* MON (Ceph Monitor Daemon)
+* OSD (Ceph Object Storage Daemon)
+* MDS (Ceph Metadata Server Daemon)
+
+The perf counters data are accessed via the Ceph admin socket.
+The intention is that data will be collected, aggregated and fed into another tool for graphing and analysis.
+
+Documentation for ceph perf counters:	http://ceph.com/docs/master/dev/perf_counters/
+
+# Dependencies
+* Ceph Storage Cluster [http://ceph.com/]
+* Ceph Administration Tool
+
+
+# Configuration
+Set proper Pulse Global Config field(s) to customize Ceph's path
+
+Ceph Config field | Description | Default
+------------ | ------------- | -------------
+**path** | Path to "ceph" executable | "/usr/bin/ceph"
+**socket_path** | The location of the ceph monitoring sockets | "/var/run/ceph"
+**socket_prefix** | The first part of all socket names | "ceph-"
+**socket_ext** | Extension for socket filenames| "asok"
+If sockets do not have prefix, set *socket_prefix="none"*
+
+By default metrics are gathered once per second.
+# Limitations
+Root privileges might be needed
+
+# Metrics
+Collect all available Ceph perf counters from:
+* MON [see more...](MON_PERFCNT.md)
+* MDS [see more...](MDS_PERFCNT.md)
+* OSD [see more...](OSD_PERFCNT.md)
+

--- a/ceph/ceph.go
+++ b/ceph/ceph.go
@@ -1,0 +1,372 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ceph
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/intelsdi-x/pulse/control/plugin"
+	"github.com/intelsdi-x/pulse/control/plugin/cpolicy"
+	"github.com/intelsdi-x/pulse/core/ctypes"
+)
+
+const (
+	// parts of returned namescape
+	ns_vendor = "intel"
+	ns_class  = "storage"
+	ns_type   = "ceph"
+
+	// Plugin namespace prefix
+	namespacePrefix = "/intel/storage/ceph"
+
+	// Daemon name index in metrics namespace: [intel storage ceph daemonName]
+	daemonNameIndex = 3
+
+	// Default path to ceph executable
+	cephBinPathDefault = "/usr/bin/ceph"
+
+	// Default Ceph's socket config
+	socketPathDefault   = "/var/run/ceph"
+	socketPrefixDefault = "ceph-"
+	socketExtDefault    = "asok"
+)
+
+// Ceph
+type Ceph struct {
+	path        string // path to ceph executable
+	keys        []string
+	daemons     []string
+	socket      Socket
+	initialized bool // after init() plugin with Config set true to avoid reinitalization
+}
+
+// Ceph Socket
+type Socket struct {
+	path   string
+	prefix string
+	ext    string
+}
+
+// PerfDumper interfaces needed for mocking exec command in ceph_test.go
+type Command interface {
+	perfDump(string, ...string) ([]byte, error)
+	lookPath(string) (string, error)
+}
+
+type RealCmd struct{}
+
+var cmd Command
+
+// execute command
+func (c *RealCmd) perfDump(command string, args ...string) ([]byte, error) {
+	return exec.Command(command, args...).Output()
+}
+
+func (c *RealCmd) lookPath(file string) (string, error) {
+	return exec.LookPath(file)
+}
+
+// trimPrefixAndSuffix returns 's' without the provided prefix and suffix strings.
+// If 's' neither starts with prefix, nor ends with suffix, 's' is returned unchanged.
+func trimPrefixAndSuffix(s string, prefix string, suffix string) string {
+	s = strings.TrimPrefix(s, prefix)
+	s = strings.TrimSuffix(s, suffix)
+	return s
+}
+
+// getCephDaemonMetrics executes "ceph --admin-daemon perf dump" command for defined daemon-socket and returns its metrics
+func (c *Ceph) getCephDaemonMetrics(mts []plugin.PluginMetricType, daemon string) ([]plugin.PluginMetricType, error) {
+	out, err := cmd.perfDump(filepath.Join(c.path, "ceph"), "--admin-daemon", filepath.Join(c.socket.path, daemon),
+		"perf", "dump")
+	timestamp := time.Now()
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Ceph perf dump command execution failed for socket %+v, err=%+v\n",
+			filepath.Join(c.socket.path, daemon), err)
+		return nil, err
+	}
+
+	var dat map[string]interface{}
+
+	if err := json.Unmarshal(out, &dat); err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot unmarshal JSON object from ceph-daemon socket, err=%+v\n", err)
+		return nil, err
+	}
+
+	metrics := []plugin.PluginMetricType{}
+
+	for _, m := range mts {
+		nlen := len(m.Namespace())
+		daemonName := trimPrefixAndSuffix(daemon, c.socket.prefix, "."+c.socket.ext)
+
+		// compare daemonName with proper component of metric's namespace [intel storage ceph daemonName]
+		if daemonName == m.Namespace()[daemonNameIndex] {
+			// get metrics defined in task for this daemon
+			dat_r := dat
+			// skip the const components of metrics namespace
+			for _, name := range m.Namespace()[daemonNameIndex+1 : nlen-1] {
+				if dat_r[name] == nil {
+					break
+				}
+				dat_r = dat_r[name].(map[string]interface{}) // get metric
+			}
+
+			hostname, _ := os.Hostname()
+			metric := plugin.PluginMetricType{
+				Namespace_: m.Namespace(),
+				Data_:      dat_r[m.Namespace()[nlen-1]], // get value of metric
+				Source_:    hostname + "/" + daemonName,
+				Timestamp_: timestamp,
+			}
+
+			metrics = append(metrics, metric)
+		}
+	}
+
+	if len(metrics) <= 0 {
+		// do not find desired metrics
+		return nil, errors.New("Do not find desired metrics for ceph-deamon")
+	}
+
+	return metrics, nil
+}
+
+// CollectMetrics returns all desired Ceph metrics defined in task manifest
+func (ceph *Ceph) CollectMetrics(mts []plugin.PluginMetricType) ([]plugin.PluginMetricType, error) {
+
+	if len(mts) <= 0 {
+		return nil, errors.New("No metrics defined to collect")
+	}
+	metrics := []plugin.PluginMetricType{}
+
+	// init ceph plugin with Config settings (only once)
+	if ceph.initialized == false {
+		if err := ceph.init(mts[0].Config().Table()); err != nil {
+			return nil, err
+		}
+		ceph.initialized = true
+	}
+
+	for _, daemon := range ceph.daemons {
+		if dmetric, err := ceph.getCephDaemonMetrics(mts, daemon); err == nil {
+			metrics = append(metrics, dmetric...)
+		}
+	}
+
+	return metrics, nil
+}
+
+// GetMetricTypes returns the metric types exposed by ceph-daemon sockets
+func (ceph *Ceph) GetMetricTypes(cfg plugin.PluginConfigType) ([]plugin.PluginMetricType, error) {
+	// init ceph plugin with Global Config params
+	if err := ceph.init(cfg.Table()); err != nil {
+		return nil, err
+	}
+
+	mts := make([]plugin.PluginMetricType, len(ceph.keys))
+	for i, k := range ceph.keys {
+		mts[i] = plugin.PluginMetricType{Namespace_: strings.Split(strings.TrimPrefix(k, "/"), "/")}
+	}
+
+	return mts, nil
+}
+
+// GetConfigPolicy returns a ConfigPolicy
+func (c *Ceph) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
+	p := cpolicy.New()
+
+	return p, nil
+}
+
+// getCephBinaryPath returns path to ceph executable
+func getCephBinaryPath(config map[string]ctypes.ConfigValue) string {
+	// check global config as a first
+	if path, ok := config["path"]; ok {
+		return path.(ctypes.ConfigValueStr).Value
+	}
+
+	// check PATH environment variable
+	if path, err := cmd.lookPath("ceph"); err == nil {
+		//command "LookPath" resolves the path to a complete name, so the "ceph" suffix needs to be trimmed
+		return strings.TrimSuffix(path, "/ceph")
+	}
+
+	return cephBinPathDefault
+}
+
+// getCephSocketConf returns path to folder contains daemon-sockets, prefix and extension of socket's name
+func getCephSocketConf(config map[string]ctypes.ConfigValue) Socket {
+	s := Socket{}
+
+	// set path to socket, defaults to "/var/run/ceph"
+	if path, ok := config["socket_path"]; ok {
+		s.path = path.(ctypes.ConfigValueStr).Value
+	} else {
+		s.path = socketPathDefault
+	}
+
+	// set socket prefix, defaults to "ceph-"
+	if prefix, ok := config["socket_prefix"]; ok {
+		s.prefix = prefix.(ctypes.ConfigValueStr).Value
+		// if equals "none", set empty socket prefix
+		if strings.ToLower(s.prefix) == "none" {
+			s.prefix = ""
+		}
+	} else {
+		s.prefix = socketPrefixDefault
+	}
+
+	// set socket extension, defaults to "asok"
+	if ext, ok := config["socket_ext"]; ok {
+		s.ext = ext.(ctypes.ConfigValueStr).Value
+	} else {
+		s.ext = socketExtDefault
+	}
+
+	return s
+}
+
+// getCephDaemonNames scans the path to ceph sockets in search of an instance which name contains specified prefix and extension.
+// Returns names of available ceph-daemon sockets
+func (s *Socket) getCephDaemonNames() []string {
+	files, err := ioutil.ReadDir(s.path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Not found any ceph-daemon socket in %+v. Check if the given path is correct\n", s.path)
+		panic(err)
+	}
+	names := []string{}
+	suffix := "." + s.ext
+	for _, f := range files {
+		// read names of all items in socket path with specific prefix-name (defaults to "ceph-") and extension (defaults to .asok)
+		if strings.HasPrefix(f.Name(), s.prefix) && strings.HasSuffix(f.Name(), suffix) {
+			names = append(names, f.Name())
+		}
+	}
+
+	return names
+}
+
+// parseMapToNamespace returns a slice contains metrics's namespace. As input there is map of strings to arbitrary data and current
+// prefix of namespace
+func parseMapToNamespace(stats map[string]interface{}, prefix string, out *[]string) {
+	for key, val := range stats {
+		switch reflect.TypeOf(val).Kind() {
+		case reflect.Map:
+			// get the next level of nested map
+			c := filepath.Join(prefix, key)
+			parseMapToNamespace(val.(map[string]interface{}), c, out)
+			break
+
+		default:
+			// append namespace to output
+			c := filepath.Join(prefix, key)
+			*out = append(*out, c)
+			break
+		}
+	}
+}
+
+// parsePerfDumpOut parses output of ceph-daemon perf dump command and returns string with name of available metrics
+func parsePerfDumpOut(cmdOut []byte) ([]string, error) {
+	prefix := "/"
+	keys := []string{}
+
+	var stats map[string]interface{}
+
+	if err := json.Unmarshal(cmdOut, &stats); err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot unmarshal JSON object from ceph-daemon socket, err=%+v\n", err)
+		return nil, err
+	}
+	parseMapToNamespace(stats, prefix, &keys)
+
+	return keys, nil
+}
+
+// Init() initalizes ceph plugin, gets information about running ceph-daemons and available metrics
+func (ceph *Ceph) init(config map[string]ctypes.ConfigValue) error {
+	// set ceph conf param
+	ceph.path = getCephBinaryPath(config)
+	ceph.socket = getCephSocketConf(config)
+
+	// get ceph daemon names based on socket details
+	ceph.daemons = ceph.socket.getCephDaemonNames()
+	if len(ceph.daemons) <= 0 {
+		return fmt.Errorf("Can not get Ceph Daemon Name(s) - check if any Ceph Daemon is running")
+	}
+
+	dkeys := make(map[string][]string)
+
+	for _, daemon := range ceph.daemons {
+		socket := filepath.Join(ceph.socket.path, daemon)
+
+		// perf dump command is `/path/to/ceph/bin --admin-daemon /path/to/exemplary/socket/osd.0.asok perf dump`
+		out, err := cmd.perfDump(filepath.Join(ceph.path, "ceph"), "--admin-daemon", socket, "perf", "dump")
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error execution of ceph-daemon perf dump command for socket %+v, err=%+v\n",
+				socket, err)
+			return err
+		}
+
+		if keys, err := parsePerfDumpOut(out); err == nil {
+			dkeys[daemon] = keys
+		} else {
+			fmt.Fprintf(os.Stderr, "Error parsing output of ceph-daemon perf dump command for socket %+v, err=%+v\n",
+				socket, err)
+		}
+
+	}
+
+	if len(dkeys) == 0 {
+		return fmt.Errorf("No Ceph metrics available")
+	}
+
+	ceph.keys = []string{}
+
+	for _, daemon := range ceph.daemons {
+		for _, key := range dkeys[daemon] {
+			daemonName := trimPrefixAndSuffix(daemon, ceph.socket.prefix, "."+ceph.socket.ext)
+			ceph.keys = append(ceph.keys, strings.Join(createNamespace(daemonName+key), "/"))
+		}
+	}
+	return nil
+}
+
+// New() returns Pulse-Plugin-Collector-Ceph instance
+func New() *Ceph {
+	ceph := &Ceph{initialized: false}
+	cmd = &RealCmd{}
+
+	return ceph
+}
+
+// createNamespace returns namespace slice of strings composed from: vendor, class, type and ceph-daemon name
+func createNamespace(name string) []string {
+	return []string{ns_vendor, ns_class, ns_type, name}
+}

--- a/ceph/ceph_test.go
+++ b/ceph/ceph_test.go
@@ -1,0 +1,594 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ceph
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	//	"strings"
+	"testing"
+
+	"github.com/intelsdi-x/pulse/control/plugin"
+	"github.com/intelsdi-x/pulse/core/cdata"
+	"github.com/intelsdi-x/pulse/core/ctypes"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var ns_prefix = []string{ns_vendor, ns_class, ns_type}
+var mockOut = []byte(`{
+			"a": {
+				"aa": 1,
+				"ab": 2
+			},
+			"b": {
+				"ba": 0
+			},
+			"c": {
+				"ca": 1,
+				"cb": {
+					"cba": 22,
+					"cbb": 22.2
+				},
+				"cc": 3 
+			} 
+		}`)
+
+var mockOutInvalid = []byte(`{
+			"a": {
+				"aa": 1,
+				"ab": 2
+			}`)
+
+var mockInUnmarshal = [][]byte{
+	[]byte(`{ "a": { "aa": 1, "ab": 2 }, "b": { "ba": 0 } }`),  //correct
+	[]byte(`{ {"a": { "aa": 1, "ab": 2 }, "b": { "ba": 0 } }`), //invalid character '{'
+	[]byte(`{ "a": { "aa": 1 "ab": 2 }, "b": { "ba": 0 } }`),   //lack of a comma after value
+	[]byte(`{ "a": { "aa": 1, "ab": 2 } "b": { "ba": 0 } }`),   //lack of a comma after }
+	[]byte(`{ "a" { "aa" 1, "ab" 2 } "b" { "ba" 0 } }`),        //lack of ":"
+}
+
+// mocking exec command
+type TestCmd struct {
+	out               []byte
+	err               error
+	look_path         string
+	look_err          error
+	env_ceph_path     string
+	env_socket_path   string
+	env_socket_prefix string
+	env_socket_ext    string
+}
+
+type TestSocket struct {
+	path   string
+	prefix string
+	ext    string
+}
+
+func (t *TestCmd) perfDump(command string, args ...string) ([]byte, error) {
+	return t.out, t.err
+}
+
+func (t *TestCmd) lookPath(file string) (string, error) {
+	return t.look_path, t.look_err
+}
+
+func Test_trimPrefixAndSuffix(t *testing.T) {
+	Convey("trimming", t, func() {
+		So(trimPrefixAndSuffix("", "", ""), ShouldEqual, "")
+		So(trimPrefixAndSuffix(" ", " ", ""), ShouldEqual, "")
+		So(trimPrefixAndSuffix(" ", "  ", ""), ShouldEqual, " ")
+		So(trimPrefixAndSuffix(" ", "  ", " "), ShouldEqual, "")
+
+		So(trimPrefixAndSuffix("ceph-mon.a.asok", "ceph-", ".asok"), ShouldEqual, "mon.a")
+		So(trimPrefixAndSuffix("ceph-osd.0.asok", "ceph-", ".asok"), ShouldEqual, "osd.0")
+		So(trimPrefixAndSuffix("mon.a.asok", "ceph-", ".asok"), ShouldEqual, "mon.a")
+		So(trimPrefixAndSuffix("mon.a.asok", "", ".asok"), ShouldEqual, "mon.a")
+		So(trimPrefixAndSuffix("ceph-mon.a.asok", "", ".asok"), ShouldEqual, "ceph-mon.a")
+		So(trimPrefixAndSuffix("ceph-mon.a.asok", "", ""), ShouldEqual, "ceph-mon.a.asok")
+		So(trimPrefixAndSuffix("ceph-mon.a.asok", "Ceph-", ".asok"), ShouldEqual, "ceph-mon.a")
+		So(trimPrefixAndSuffix("Ceph-Mon.a.asok", "Ceph-", ".asok"), ShouldEqual, "Mon.a")
+		So(trimPrefixAndSuffix("ceph-Mon.a.ASOK", "ceph-", ".ASOK"), ShouldEqual, "Mon.a")
+
+		So(trimPrefixAndSuffix("", "ABC", "XYZ"), ShouldEqual, "")
+		So(trimPrefixAndSuffix("A CtestX_Z", "A C", "X_Z"), ShouldEqual, "test")
+		So(trimPrefixAndSuffix("ABCtestX_Z", "CBA", "X_Z"), ShouldEqual, "ABCtest")
+		So(trimPrefixAndSuffix("   testX_Z", "A C", "X_Z"), ShouldEqual, "   test")
+		So(trimPrefixAndSuffix("   testX_Z", "A C", "X_Z"), ShouldEqual, "   test")
+		So(trimPrefixAndSuffix("12Atest3  ", "12A", "3  "), ShouldEqual, "test")
+	})
+}
+
+func Test_getCephDaemonNames(t *testing.T) {
+	socketTestA := &Socket{path: "./test/", prefix: "prefix-", ext: "ext"}
+	socketTestB := &Socket{path: "./test/", prefix: "", ext: "ext"}
+	socketTestC := &Socket{path: "./test/", prefix: "prefix-", ext: "extB"}
+	socketTestD := &Socket{path: "./test/", prefix: "", ext: ""}
+
+	Convey("obtaining daemon names when there is no directory", t, func() {
+		So(func() { socketTestA.getCephDaemonNames() }, ShouldPanic)
+	})
+
+	os.Mkdir("test", os.ModePerm)
+
+	Convey("obtaining daemon names when there is no file in the indicated directory", t, func() {
+		So(func() { socketTestA.getCephDaemonNames() }, ShouldNotPanic)
+		result := socketTestA.getCephDaemonNames()
+		So(result, ShouldBeEmpty)
+	})
+
+	os.Create("test/socket.aaa")
+	os.Create("test/socket.bbb")
+
+	Convey("obtaining daemon names when there is no proper file in the indicated directory", t, func() {
+		So(func() { socketTestA.getCephDaemonNames() }, ShouldNotPanic)
+		result := socketTestA.getCephDaemonNames()
+		So(result, ShouldBeEmpty)
+	})
+
+	os.Create("test/prefix-socket1.ext")
+	os.Create("test/prefix-socket2.ext")
+	os.Create("test/socket3.ext")
+	os.Create("test/prefix-socket4.extB")
+
+	Convey("obtaining daemon names from existing files (1)", t, func() {
+		result := socketTestA.getCephDaemonNames()
+		So(result, ShouldContain, "prefix-socket1.ext")
+		So(result, ShouldContain, "prefix-socket2.ext")
+	})
+
+	Convey("obtaining daemon names from existing files (2)", t, func() {
+		result := socketTestB.getCephDaemonNames()
+		So(result, ShouldContain, "socket3.ext")
+	})
+
+	Convey("obtaining daemon names from existing files (3)", t, func() {
+		result := socketTestC.getCephDaemonNames()
+		So(result, ShouldContain, "prefix-socket4.extB")
+	})
+
+	Convey("obtaining daemon names from existing files (4)", t, func() {
+		result := socketTestD.getCephDaemonNames()
+		So(result, ShouldBeEmpty)
+	})
+
+	os.RemoveAll("test/")
+
+}
+
+func createMockMetrics(count uint64, hostname string) []plugin.PluginMetricType {
+	metrics := make([]plugin.PluginMetricType, count)
+	for i, _ := range metrics {
+
+		metrics[i] = plugin.PluginMetricType{
+			Namespace_: []string{"test", "metric", "namespace"},
+			Data_:      1.01 + float32(i),
+			Source_:    hostname,
+		}
+	}
+
+	return metrics
+}
+
+func checkMetricsResemblance(metrics []plugin.PluginMetricType, metricsMock []plugin.PluginMetricType) {
+	for i, mock := range metricsMock {
+		So(metrics[i].Namespace(), ShouldResemble, mock.Namespace())
+		So(metrics[i].Source(), ShouldEqual, mock.Source())
+		So(metrics[i].Data(), ShouldEqual, mock.Data())
+	}
+}
+
+// desiredMtsCnt returns number of desired metrics to collect from specific daemon
+func desiredMtsCnt(daemonName string, metrics []plugin.PluginMetricType) int {
+	cnt := 0
+	for _, m := range metrics {
+		if m.Namespace()[daemonNameIndex] == daemonName {
+			cnt++
+		}
+	}
+
+	return cnt
+}
+
+func Test_getCephDaemonMetrics(t *testing.T) {
+	mts := []plugin.PluginMetricType{
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "storage", "ceph", "mds.a", "a", "aa"},
+		},
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "storage", "ceph", "mds.a", "b", "ba"},
+		},
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "storage", "ceph", "mds.a", "c", "cb", "cba"},
+		},
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "storage", "ceph", "mds.a", "c", "cb", "cbb"},
+		},
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "storage", "ceph", "mds.b", "a", "aa"},
+		},
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "storage", "ceph", "mds.b", "a", "cc"},
+		},
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "storage", "ceph", "mds.c", "no", "nono"},
+		},
+	}
+
+	testCeph := &Ceph{}
+
+	Convey("invalid getting metrics, perf dump command execution error", t, func() {
+		cmd = &TestCmd{err: errors.New("exit status 1")}
+
+		So(func() { testCeph.getCephDaemonMetrics(mts, "mds.a") }, ShouldNotPanic)
+		result, err := testCeph.getCephDaemonMetrics(mts, "mds.a")
+		So(result, ShouldBeEmpty)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("invalid getting metrics, empty perf dump output", t, func() {
+		cmd = &TestCmd{}
+		So(func() { testCeph.getCephDaemonMetrics(mts, "mds.a") }, ShouldNotPanic)
+		result, err := testCeph.getCephDaemonMetrics(mts, "mds.a")
+		So(result, ShouldBeEmpty)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("unmarshal perf dump output", t, func() {
+		//first mock in mockInUnmarshal is correct
+		cmd = &TestCmd{out: mockInUnmarshal[0]}
+		dName := "mds.a"
+		So(func() { testCeph.getCephDaemonMetrics(mts, dName) }, ShouldNotPanic)
+		result, err := testCeph.getCephDaemonMetrics(mts, dName)
+		So(result, ShouldNotBeEmpty)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("invalid unmarshal perf dump output, incorrect json format", t, func() {
+		for _, moi := range mockInUnmarshal[1:] {
+			cmd = &TestCmd{out: moi}
+			dName := "mds.a"
+			So(func() { testCeph.getCephDaemonMetrics(mts, dName) }, ShouldNotPanic)
+			result, err := testCeph.getCephDaemonMetrics(mts, dName)
+			So(result, ShouldBeEmpty)
+			So(err, ShouldNotBeNil)
+		}
+	})
+
+	Convey("no defined desired metrics for daemon", t, func() {
+		cmd = &TestCmd{out: mockOut}
+		dName := "mds.d"
+		So(func() { testCeph.getCephDaemonMetrics(mts, dName) }, ShouldNotPanic)
+		result, err := testCeph.getCephDaemonMetrics(mts, dName)
+		So(result, ShouldBeEmpty)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("no available desired metrics for daemon", t, func() {
+		cmd = &TestCmd{out: mockOut}
+		dName := "mds.c"
+		So(func() { testCeph.getCephDaemonMetrics(mts, dName) }, ShouldNotPanic)
+		result, err := testCeph.getCephDaemonMetrics(mts, dName)
+		So(len(result), ShouldEqual, desiredMtsCnt(dName, mts))
+		So(result[0].Data(), ShouldBeNil)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("get ceph-daemon metrics (1)", t, func() {
+		cmd = &TestCmd{out: mockOut}
+		dName := "mds.a"
+		So(func() { testCeph.getCephDaemonMetrics(mts, dName) }, ShouldNotPanic)
+		result, err := testCeph.getCephDaemonMetrics(mts, dName)
+		So(result, ShouldNotBeEmpty)
+		So(len(result), ShouldEqual, desiredMtsCnt(dName, mts))
+		So(result[0].Data(), ShouldNotBeNil)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("get ceph-daemon metrics (2)", t, func() {
+		cmd = &TestCmd{out: mockOut}
+		dName := "mds.b"
+		So(func() { testCeph.getCephDaemonMetrics(mts, dName) }, ShouldNotPanic)
+		result, err := testCeph.getCephDaemonMetrics(mts, dName)
+		So(result, ShouldNotBeEmpty)
+		So(len(result), ShouldEqual, desiredMtsCnt(dName, mts))
+		So(result[0].Data(), ShouldNotBeNil)
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestGetMetricTypes(t *testing.T) {
+	// Testing GetMetricTypes function covers checking initialization of Ceph plugin
+
+	// mock ceph socket
+	os.Mkdir("test", os.ModePerm)
+	os.Create("test/ceph-mds.a.asok")
+	os.Create("test/ceph-mds.b.asok")
+	os.Create("test/ceph-mds.c.asok")
+
+	// set ceph socket conf value
+	cfg := plugin.NewPluginConfigType()
+	cfg.AddItem("socket_path", ctypes.ConfigValueStr{Value: "./test"})
+	cfg.AddItem("socket_prefix", ctypes.ConfigValueStr{Value: "ceph-"})
+	cfg.AddItem("socket_ext", ctypes.ConfigValueStr{Value: "asok"})
+
+	Convey("init ceph plugin and getting metric namespace", t, func() {
+		ceph := &Ceph{}
+		cmd = &TestCmd{out: mockOut}
+		So(func() { ceph.GetMetricTypes(cfg) }, ShouldNotPanic)
+		result, err := ceph.GetMetricTypes(cfg)
+		So(result, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("getting metric namespace with error - perf dump output is not valid", t, func() {
+		ceph := &Ceph{}
+		cmd = &TestCmd{out: mockOutInvalid}
+		So(func() { ceph.GetMetricTypes(cfg) }, ShouldNotPanic)
+		result, err := ceph.GetMetricTypes(cfg)
+		So(result, ShouldBeEmpty)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("getting metric namespace with error - perf dump execution error", t, func() {
+		ceph := &Ceph{}
+		cmd = &TestCmd{err: errors.New("execution error")}
+		So(func() { ceph.GetMetricTypes(cfg) }, ShouldNotPanic)
+		result, err := ceph.GetMetricTypes(cfg)
+		So(result, ShouldBeEmpty)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("getting metric namespace with error - perf dump output is empty", t, func() {
+		ceph := &Ceph{}
+		moi := []byte(fmt.Sprintf("\n\n\n\n"))
+		cmd = &TestCmd{out: moi}
+		So(func() { ceph.GetMetricTypes(cfg) }, ShouldNotPanic)
+		result, err := ceph.GetMetricTypes(cfg)
+		So(result, ShouldBeEmpty)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("getting metric namespace with error - none perf dump output", t, func() {
+		ceph := &Ceph{}
+		cmd = &TestCmd{}
+		So(func() { ceph.GetMetricTypes(cfg) }, ShouldNotPanic)
+		result, err := ceph.GetMetricTypes(cfg)
+		So(result, ShouldBeEmpty)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("invalid path to ceph-daemon sockets", t, func() {
+		ceph := &Ceph{}
+		cmd = &TestCmd{out: mockOut}
+		cfg_invalid := plugin.NewPluginConfigType()
+		cfg_invalid.AddItem("socket_path", ctypes.ConfigValueStr{Value: "./test_invalid"})
+		cfg_invalid.AddItem("socket_prefix", ctypes.ConfigValueStr{Value: "ceph-"})
+		cfg_invalid.AddItem("socket_ext", ctypes.ConfigValueStr{Value: "asok"})
+		So(func() { ceph.GetMetricTypes(cfg_invalid) }, ShouldPanic)
+	})
+
+	Convey("no ceph-daemon sockets available with set prefix", t, func() {
+		ceph := &Ceph{}
+		cmd = &TestCmd{out: mockOut}
+		cfg_inv_prefix := plugin.NewPluginConfigType()
+		cfg_inv_prefix.AddItem("socket_path", ctypes.ConfigValueStr{Value: "./test"})
+		cfg_inv_prefix.AddItem("socket_prefix", ctypes.ConfigValueStr{Value: "ceph_inv-"})
+		So(func() { ceph.GetMetricTypes(cfg_inv_prefix) }, ShouldNotPanic)
+		result, err := ceph.GetMetricTypes(cfg_inv_prefix)
+		So(result, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("no ceph-daemon sockets available with set extension", t, func() {
+		ceph := &Ceph{}
+		cmd = &TestCmd{out: mockOut}
+		cfg_inv_ext := plugin.NewPluginConfigType()
+		cfg_inv_ext.AddItem("socket_path", ctypes.ConfigValueStr{Value: "./test"})
+		cfg_inv_ext.AddItem("socket_ext", ctypes.ConfigValueStr{Value: "asok_inv"})
+		So(func() { ceph.GetMetricTypes(cfg_inv_ext) }, ShouldNotPanic)
+		result, err := ceph.GetMetricTypes(cfg_inv_ext)
+		So(result, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+	})
+
+	os.RemoveAll("test/")
+}
+
+func Test_parsePerfDumpOut(t *testing.T) {
+	Convey("parse perf dump output when output is empty", t, func() {
+		out := []byte{}
+		So(func() { parsePerfDumpOut(out) }, ShouldNotPanic)
+		result, err := parsePerfDumpOut(out)
+		So(result, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("parse perf dump returns no error", t, func() {
+		So(func() { parsePerfDumpOut(mockOut) }, ShouldNotPanic)
+		result, err := parsePerfDumpOut(mockOut)
+		So(result, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("parse perf dump returns error", t, func() {
+		So(func() { parsePerfDumpOut(mockOutInvalid) }, ShouldNotPanic)
+		result, err := parsePerfDumpOut(mockOutInvalid)
+		So(result, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+	})
+}
+
+func Test_getCephBinaryPath(t *testing.T) {
+	path := "/path/to/ceph/bin"
+
+	Convey("path Ceph executable in Pulse Global Config", t, func() {
+		cmd = &TestCmd{}
+		cfg := plugin.NewPluginConfigType()
+		cfg.AddItem("path", ctypes.ConfigValueStr{Value: path})
+
+		So(func() { getCephBinaryPath(cfg.Table()) }, ShouldNotPanic)
+		result := getCephBinaryPath(cfg.Table())
+		So(result, ShouldEqual, path)
+	})
+
+	Convey("looking for Ceph executable in $PATH with no error", t, func() {
+		cfg := plugin.NewPluginConfigType()
+		cmd = &TestCmd{look_path: path}
+		So(func() { getCephBinaryPath(cfg.Table()) }, ShouldNotPanic)
+		result := getCephBinaryPath(cfg.Table())
+		So(result, ShouldEqual, path)
+	})
+
+	Convey("looking for Ceph executable in $PATH with error", t, func() {
+		cfg := plugin.NewPluginConfigType()
+		cmd = &TestCmd{look_path: path, look_err: errors.New("error")}
+		So(func() { getCephBinaryPath(cfg.Table()) }, ShouldNotPanic)
+		result := getCephBinaryPath(cfg.Table())
+		// getting default path to ceph executable
+		So(result, ShouldEqual, cephBinPathDefault)
+	})
+}
+
+func Test_getSocketConf(t *testing.T) {
+	Convey("defaults Ceph socket details", t, func() {
+		cmd = &TestCmd{}
+		cfg := plugin.NewPluginConfigType()
+
+		So(func() { getCephSocketConf(cfg.Table()) }, ShouldNotPanic)
+		result := getCephSocketConf(cfg.Table())
+		So(result.path, ShouldEqual, socketPathDefault)
+		So(result.prefix, ShouldEqual, socketPrefixDefault)
+		So(result.ext, ShouldEqual, socketExtDefault)
+	})
+
+	Convey("customize Ceph socket conf in Pulse Global Conf", t, func() {
+		path := "path/to/ceph/socket"
+		prefix := "test-"
+		extension := "asdf"
+		cmd = &TestCmd{}
+		cfg := plugin.NewPluginConfigType()
+		cfg.AddItem("socket_path", ctypes.ConfigValueStr{Value: path})
+		cfg.AddItem("socket_prefix", ctypes.ConfigValueStr{Value: prefix})
+		cfg.AddItem("socket_ext", ctypes.ConfigValueStr{Value: extension})
+
+		So(func() { getCephSocketConf(cfg.Table()) }, ShouldNotPanic)
+		result := getCephSocketConf(cfg.Table())
+		So(result.path, ShouldEqual, path)
+		So(result.prefix, ShouldEqual, prefix)
+		So(result.ext, ShouldEqual, extension)
+	})
+
+	Convey("customize Ceph socket prefix, set none", t, func() {
+		cmd = &TestCmd{}
+		cfg := plugin.NewPluginConfigType()
+		cfg.AddItem("socket_prefix", ctypes.ConfigValueStr{Value: "none"})
+		So(func() { getCephSocketConf(cfg.Table()) }, ShouldNotPanic)
+		result := getCephSocketConf(cfg.Table())
+		So(result.prefix, ShouldBeEmpty)
+	})
+}
+
+func Test_CollectMetrics(t *testing.T) {
+	// folder for mocked ceph socket, empty in the beginning
+	os.Mkdir("test", os.ModePerm)
+
+	mts := []plugin.PluginMetricType{
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "storage", "ceph", "osd.2", "a", "aa"},
+		},
+		plugin.PluginMetricType{
+			Namespace_: []string{"intel", "storage", "ceph", "osd.3", "c", "cb", "cba"},
+		},
+	}
+
+	config := cdata.NewNode()
+	for i, _ := range mts {
+		mts[i].Config_ = config
+	}
+
+	// set ceph socket conf value
+	config.AddItem("socket_path", ctypes.ConfigValueStr{Value: "./test"})
+	config.AddItem("socket_prefix", ctypes.ConfigValueStr{Value: "none"})
+	config.AddItem("socket_ext", ctypes.ConfigValueStr{Value: "asok"})
+
+	Convey("no metrics defined to collect", t, func() {
+		ceph := &Ceph{}
+		cmd = &TestCmd{out: mockOut}
+		ceph.daemons = []string{}
+		mts_empty := []plugin.PluginMetricType{}
+		So(func() { ceph.CollectMetrics(mts_empty) }, ShouldNotPanic)
+		result, err := ceph.CollectMetrics(mts_empty)
+		So(result, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("no ceph daemon is running", t, func() {
+		// none mocked ceph socket in ./test
+		ceph := &Ceph{}
+		cmd = &TestCmd{out: mockOut}
+		ceph.daemons = []string{}
+		So(func() { ceph.CollectMetrics(mts) }, ShouldNotPanic)
+		result, err := ceph.CollectMetrics(mts)
+		So(result, ShouldBeEmpty)
+		So(err, ShouldNotBeNil)
+	})
+
+	// create ceph socket
+	os.Create("test/osd.0.asok")
+	os.Create("test/osd.1.asok")
+
+	Convey("try collecting metrics for not available socket", t, func() {
+		// metrics for osd.2 and osd.3 are not available
+		ceph := &Ceph{}
+		cmd = &TestCmd{out: mockOut}
+		So(func() { ceph.CollectMetrics(mts) }, ShouldNotPanic)
+		result, err := ceph.CollectMetrics(mts)
+		So(result, ShouldBeEmpty)
+		So(err, ShouldBeNil)
+	})
+
+	// create additional ceph socket
+	os.Create("test/osd.2.asok")
+	os.Create("test/osd.3.asok")
+
+	Convey("collect metrics with no errors", t, func() {
+		ceph := &Ceph{}
+		cmd = &TestCmd{out: mockOut}
+		So(func() { ceph.CollectMetrics(mts) }, ShouldNotPanic)
+		result, err := ceph.CollectMetrics(mts)
+		So(len(result), ShouldEqual, len(mts))
+
+		for _, r := range result {
+			So(r.Data(), ShouldNotBeNil)
+		}
+		So(err, ShouldBeNil)
+	})
+	os.RemoveAll("test/")
+}
+
+func Test_New(t *testing.T) {
+	Convey("create new Ceph structure", t, func() {
+		So(func() { New() }, ShouldNotPanic)
+		result := New()
+		So(result, ShouldNotBeNil)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,46 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	// Import the pulse plugin library
+	"github.com/intelsdi-x/pulse/control/plugin"
+
+	// Import our collector plugin implementation
+	"github.com/intelsdi-x/pulse-plugin-collector-ceph/ceph"
+)
+
+// meta data about plugin
+const (
+	name       = "ceph"
+	version    = 1
+	pluginType = plugin.CollectorPluginType
+)
+
+// plugin bootstrap
+func main() {
+	plugin.Start(
+		plugin.NewPluginMeta(name, version, pluginType, []string{}, []string{plugin.PulseGOBContentType}, plugin.ConcurrencyCount(1)),
+		ceph.New(),
+		os.Args[1],
+	)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,34 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMain(t *testing.T) {
+	Convey("ensure plugin loads and responds", t, func() {
+		os.Args = []string{"", "{\"NoDaemon\": true}"}
+		So(func() { main() }, ShouldNotPanic)
+	})
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+GITVERSION=`git describe --always`
+SOURCEDIR=$1
+BUILDDIR=$SOURCEDIR/build
+PLUGIN=`echo $SOURCEDIR | grep -oh "pulse-.*"`
+ROOTFS=$BUILDDIR/rootfs
+BUILDCMD='go build -a -ldflags "-w"'
+
+echo
+echo "****  Pulse Plugin Build  ****"
+echo
+
+# Disable CGO for builds
+export CGO_ENABLED=0
+
+# Clean build bin dir
+rm -rf $ROOTFS/*
+
+# Make dir
+mkdir -p $ROOTFS
+
+# Build plugin
+echo "Source Dir = $SOURCEDIR"
+echo "Building Pulse Plugin: $PLUGIN"
+$BUILDCMD -o $ROOTFS/$PLUGIN
+

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash -e
+# The script does automatic checking on a Go package and its sub-packages, including:
+# 1. gofmt         (http://golang.org/cmd/gofmt/)
+# 2. goimports     (https://github.com/bradfitz/goimports)
+# 3. golint        (https://github.com/golang/lint)
+# 4. go vet        (http://golang.org/cmd/vet)
+# 5. race detector (http://blog.golang.org/race-detector)
+# 6. test coverage (http://blog.golang.org/cover)
+
+# Capture what test we should run
+TEST_SUITE=$1
+
+if [[ $TEST_SUITE == "unit" ]]; then
+	go get github.com/axw/gocov/gocov
+	go get github.com/mattn/goveralls
+	go get -u github.com/golang/lint/golint
+	go get golang.org/x/tools/cmd/vet
+	go get golang.org/x/tools/cmd/goimports
+	go get github.com/smartystreets/goconvey/convey
+	go get golang.org/x/tools/cmd/cover
+	
+	COVERALLS_TOKEN=t47LG6BQsfLwb9WxB56hXUezvwpED6D11
+	TEST_DIRS="main.go ceph/"
+	VET_DIRS=". ./ceph/..."
+
+	set -e
+
+	# Automatic checks
+	echo "gofmt"
+	test -z "$(gofmt -l -d $TEST_DIRS | tee /dev/stderr)"
+
+	echo "goimports"
+	test -z "$(goimports -l -d $TEST_DIRS | tee /dev/stderr)"
+
+	# Useful but should not fail on link per: https://github.com/golang/lint
+	# "The suggestions made by golint are exactly that: suggestions. Golint is not perfect,
+	# and has both false positives and false negatives. Do not treat its output as a gold standard.
+	# We will not be adding pragmas or other knobs to suppress specific warnings, so do not expect
+	# or require code to be completely "lint-free". In short, this tool is not, and will never be,
+	# trustworthy enough for its suggestions to be enforced automatically, for example as part of
+	# a build process"
+	# echo "golint"
+	# golint ./...
+
+	echo "go vet"
+	go vet $VET_DIRS
+	# go test -race ./... - Lets disable for now
+ 
+	# Run test coverage on each subdirectories and merge the coverage profile.
+	echo "mode: count" > profile.cov
+ 
+	# Standard go tooling behavior is to ignore dirs with leading underscors
+	for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -not -path './examples/*' -not -path './scripts/*' -not -path './build/*' -not -path './Godeps/*' -type d);
+	do
+		if ls $dir/*.go &> /dev/null; then
+	    		go test --tags=unit -covermode=count -coverprofile=$dir/profile.tmp $dir
+	    		if [ -f $dir/profile.tmp ]
+	    		then
+	        		cat $dir/profile.tmp | tail -n +2 >> profile.cov
+	        		rm $dir/profile.tmp
+	    		fi
+		fi
+	done
+ 
+	go tool cover -func profile.cov
+ 
+	# Disabled Coveralls.io for now
+	# To submit the test coverage result to coveralls.io,
+	# use goveralls (https://github.com/mattn/goveralls)
+	# goveralls -coverprofile=profile.cov -service=travis-ci -repotoken t47LG6BQsfLwb9WxB56hXUezvwpED6D11
+	#
+	# If running inside Travis we update coveralls. We don't want his happening on Macs
+	# if [ "$TRAVIS" == "true" ]
+	# then
+	#     n=1
+	#     until [ $n -ge 6 ]
+	#     do
+	#         echo "posting to coveralls attempt $n of 5"
+	#         goveralls -v -coverprofile=profile.cov -service travis.ci -repotoken $COVERALLS_TOKEN && break
+	#         n=$[$n+1]
+	#         sleep 30
+	#     done
+	# fi
+fi


### PR DESCRIPTION
## Pulse Ceph Perf Counters Collector Plugin
# Description

Collect Ceph performance counters from the Ceph Storage System for:
- MON (Ceph Monitor Daemon)
- OSD (Ceph Object Storage Daemon)
- MDS (Ceph Metadata Server Daemon)
# Metrics

Collect all available Ceph perf counters from:
- [MON](MON_PERFCNT.md)
- [MDS](MDS_PERFCNT.md)
- [OSD](OSD_PERFCNT.md)
# Dependencies
- Ceph Storage Cluster [http://ceph.com/]
- Ceph Administration Tool

Documentation for ceph perf counters:   http://ceph.com/docs/master/dev/perf_counters/
# Sample output (from "pulsectl task watch"):

![image](https://cloud.githubusercontent.com/assets/11335874/10402313/fb562096-6ec4-11e5-9b79-45a4a7241bf6.png)
