### PR TITLE
Incremented the version of plugin after move to Jewel

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ import (
 // meta data about plugin
 const (
 	name       = "ceph"
-	version    = 4
+	version    = 5
 	pluginType = plugin.CollectorPluginType
 )
 


### PR DESCRIPTION
Summary of changes:
- Incremented plugin version
- Added tag:  `git tag -a 5 -m "snap plugin collector ceph v5"`


How to verify it:
- loaded plugin should have version 5

Testing done:
- loaded ceph collector plugin

